### PR TITLE
Add support for table-specific 'flags'

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 			}
 		}
 
-		db_tables = append(db_tables, Table{table_name, where})
+		db_tables = append(db_tables, Table{table_name, where, flags})
 	}
 
 	outfile, err := os.Create("./output.sql")

--- a/main.go
+++ b/main.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"database/sql"
 	"flag"
-	_ "github.com/go-sql-driver/mysql"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
+
+	_ "github.com/go-sql-driver/mysql"
 )
 
 func handleError(err interface{}) {
@@ -72,7 +72,7 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 	type Table struct {
 		table_name string
 		where      string
-    flags      string
+		flags      string
 	}
 	db_tables := []Table{}
 
@@ -106,10 +106,13 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 	handleError(err)
 	defer outfile.Close()
 
+	// Add a create databse command to the dump file
+	outfile.WriteString("CREATE DATABASE " + database)
+
 	for i := 0; i < len(db_tables); i++ {
 		table := db_tables[i]
 		log.Println("Running mysql_dump for", table.table_name)
-		command := "mysqldump --lock-tables=false --add-drop-database --compact "
+		command := "mysqldump --lock-tables=false --compact "
 		command += "--host " + host + " --user " + user + " -p" + password + " "
 		command += "--where=\"" + table.where + "\" "
 		command += table.flags + " "

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 		command := "mysqldump --lock-tables=false --compact "
 		command += "--host " + host + " --user " + user + " -p" + password + " "
 		command += "--where=\"" + table.where + "\" "
-		command += table.flags
+		command += table.flags + " "
 		command += database + " " + table.table_name
 
 		cmd := exec.Command("/bin/bash", "-c", command)

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
-
+    "gopkg.in/yaml.v2"
 	_ "github.com/go-sql-driver/mysql"
 )
 

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 	for i := 0; i < len(db_tables); i++ {
 		table := db_tables[i]
 		log.Println("Running mysql_dump for", table.table_name)
-		command := "mysqldump --lock-tables=false --compact "
+		command := "mysqldump --lock-tables=false --add-drop-database --compact "
 		command += "--host " + host + " --user " + user + " -p" + password + " "
 		command += "--where=\"" + table.where + "\" "
 		command += table.flags + " "

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 	type Table struct {
 		table_name string
 		where      string
+    flags      string
 	}
 	db_tables := []Table{}
 

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 		Tables []struct {
 			TableName string `yaml:"table_name"`
 			Where     string `yaml:"where"`
+			Flags     string `yaml:"flags"`
 		}
 	}
 	data, err := ioutil.ReadFile(config_file)
@@ -88,9 +89,11 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 		}
 
 		where := "1=1"
+		flags := ""
 		for i := 0; i < len(config.Tables); i++ {
 			if config.Tables[i].TableName == table_name {
 				where = config.Tables[i].Where
+				flags = config.Tables[i].Flags
 				break
 			}
 		}
@@ -108,6 +111,7 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 		command := "mysqldump --lock-tables=false --compact "
 		command += "--host " + host + " --user " + user + " -p" + password + " "
 		command += "--where=\"" + table.where + "\" "
+		command += table.flags
 		command += database + " " + table.table_name
 
 		cmd := exec.Command("/bin/bash", "-c", command)

--- a/main.go
+++ b/main.go
@@ -107,7 +107,9 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 	defer outfile.Close()
 
 	// Add a create databse command to the dump file
+    // This allows us to restore multiple databases at once
 	outfile.WriteString("CREATE DATABASE " + database + ";\n")
+	outfile.WriteString("USE " + database + ";\n")
 
 	for i := 0; i < len(db_tables); i++ {
 		table := db_tables[i]

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func dump(user, host, port, password, database, config_file string, db *sql.DB) 
 	defer outfile.Close()
 
 	// Add a create databse command to the dump file
-	outfile.WriteString("CREATE DATABASE " + database)
+	outfile.WriteString("CREATE DATABASE " + database + ";\n")
 
 	for i := 0; i < len(db_tables); i++ {
 		table := db_tables[i]


### PR DESCRIPTION
This PR adds the ability to add table-specific flags to your config file. I had to add this because mysqldump handles emoji weirdly, so I wanted to dump a couple of tables with specific flags to ensure the emojis came over, but not have those flags that affect all my tables.

You can now add a 'flags:' field to your config file. Tables that have a 'flags' field will also need a 'where' (I suggest "1=1")